### PR TITLE
fix(deps): downgrade to core-js@2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,13 @@
+
+name: Build smoke test
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v1
+      with:
+        node-version: '10.x'
+    - run: yarn install
+    - run: yarn build

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "babel-plugin-module-resolver": "^4.0.0",
     "babel-preset-vue": "^2.0.2",
     "browser-env": "^3.2.5",
+    "core-js": "2",
     "eslint": "^6.1.0",
     "eslint-config-prettier": "^6.10.1",
     "eslint-plugin-nuxt": "^0.5.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4594,7 +4594,7 @@ core-js-pure@^3.0.1:
   resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.6.5.tgz#c79e75f5e38dbc85a662d91eea52b8256d53b813"
   integrity sha512-lacdXOimsiD0QyNf9BC/mxivNJ/ybBGJXQFKzRekp1WTHoVUWsUHEn+2T8GJAzzIhyOuXA+gOxCVN3l+5PLPUA==
 
-core-js@^2.6.5:
+core-js@2, core-js@^2.6.5:
   version "2.6.11"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.11.tgz#38831469f9922bded8ee21c9dc46985e0399308c"
   integrity sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==


### PR DESCRIPTION
This pull request will fix a regression introduced eventually into the
project due to some package update, that causes the application to not
start, because Nuxt is not compatible with core-js@3 at the moment.

Additionally, this pull request introduces a GitHub action that attempts
to run `yarn build` in order to make sure that the project is at least
compilable. This is a smoke test that should not replace endpoint
testing to assert that at least some pages work.
