### PR TITLE
feat: change the build mode to universal

### DIFF
--- a/components/desktop_menu/RadialMenu.vue
+++ b/components/desktop_menu/RadialMenu.vue
@@ -1,26 +1,29 @@
 <template>
-  <div v-if="!isHidden">
-    <radial-menu
-      id="main-menu"
-      :item-size="50"
-      :radius="120"
-      :angle-restriction="180"
-      style="margin: auto; margin-top: 300px; background-color: white;"
-    >
-      <radial-menu-item
-        v-for="(item, index) in items"
-        :key="item"
-        style="background-color: white;"
-        @click="() => handleClick(item)"
+  <client-only>
+    <div v-if="!isHidden">
+      <radial-menu
+        id="main-menu"
+        :item-size="50"
+        :radius="120"
+        :angle-restriction="180"
+        style="margin: auto; margin-top: 300px; background-color: white;"
       >
-        <span>{{ index }}</span>
-      </radial-menu-item>
-    </radial-menu>
-  </div>
+        <radial-menu-item
+          v-for="(item, index) in items"
+          :key="item"
+          style="background-color: white;"
+          @click="() => handleClick(item)"
+        >
+          <span>{{ index }}</span>
+        </radial-menu-item>
+      </radial-menu>
+    </div>
+  </client-only>
 </template>
 
 <script>
-import { RadialMenu, RadialMenuItem } from 'vue-radial-menu'
+import RadialMenu from 'vue-radial-menu/src/components/RadialMenu.vue'
+import RadialMenuItem from 'vue-radial-menu/src/components/RadialMenuItem.vue'
 
 export default {
   components: {

--- a/components/desktop_menu/RadialMenu.vue
+++ b/components/desktop_menu/RadialMenu.vue
@@ -1,24 +1,22 @@
 <template>
-  <client-only>
-    <div v-if="!isHidden">
-      <radial-menu
-        id="main-menu"
-        :item-size="50"
-        :radius="120"
-        :angle-restriction="180"
-        style="margin: auto; margin-top: 300px; background-color: white;"
+  <div v-if="!isHidden">
+    <radial-menu
+      id="main-menu"
+      :item-size="50"
+      :radius="120"
+      :angle-restriction="180"
+      style="margin: auto; margin-top: 300px; background-color: white;"
+    >
+      <radial-menu-item
+        v-for="(item, index) in items"
+        :key="item"
+        style="background-color: white;"
+        @click="() => handleClick(item)"
       >
-        <radial-menu-item
-          v-for="(item, index) in items"
-          :key="item"
-          style="background-color: white;"
-          @click="() => handleClick(item)"
-        >
-          <span>{{ index }}</span>
-        </radial-menu-item>
-      </radial-menu>
-    </div>
-  </client-only>
+        <span>{{ index }}</span>
+      </radial-menu-item>
+    </radial-menu>
+  </div>
 </template>
 
 <script>

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -1,5 +1,5 @@
 export default {
-  mode: 'spa',
+  mode: 'universal',
   /*
    ** Headers of the page
    */


### PR DESCRIPTION
This commit will set by default the application mode to universal,
previously set to spa. The reason it was set to spa is because
vue-radial-menu is not compatible with SSR when using the minified dist/
bundle, because it somehow packs too much dependencies.

However, if instead of importing vue-radial-menu (which imports the
whole bundle at dist/radialMenu.common.js), each .vue file is imported
separately, the application works fine using server side rendering.